### PR TITLE
Uninstall existing copies of 7-Zip

### DIFF
--- a/repository/7-zip/x86/7-Zip x86.bat
+++ b/repository/7-zip/x86/7-Zip x86.bat
@@ -46,6 +46,11 @@ pushd "%~dp0"
 ::::::::::::::::::
 :: INSTALLATION ::
 ::::::::::::::::::
+:: Uninstall existing copies of 7-Zip
+IF EXIST "%ProgramFiles%\7-Zip\Uninstall.exe" "%ProgramFiles%\7-Zip\Uninstall.exe" /S /V"/qn /norestart"
+IF EXIST "%ProgramFiles(x86)%\7-Zip\Uninstall.exe" "%ProgramFiles(x86)%\7-Zip\Uninstall.exe" /S /V"/qn /norestart"
+wmic product where "name like '7-Zip%%'" uninstall /nointeractive
+
 :: Install the package from the local folder (if all files are in the same directory)
 "%BINARY%" %FLAGS%
 


### PR DESCRIPTION
Uninstall existing copies of 7-Zip. This installer doesn't upgrade or remove copies of 7-zip installed from 7-zip.org or through ninite.com